### PR TITLE
Updated the Ssl_line_Item_commodity_code to truncate to 12 characters…

### DIFF
--- a/src/LeggettAndPlatt.Extensions/Modules/Cart/Services/Handlers/UpdateCartHandler/ElavonPostLevel3Data.cs
+++ b/src/LeggettAndPlatt.Extensions/Modules/Cart/Services/Handlers/UpdateCartHandler/ElavonPostLevel3Data.cs
@@ -178,7 +178,7 @@ namespace LeggettAndPlatt.Extensions.Modules.Cart.Services.Handlers.UpdateCartHa
                     string shortDescription = ReplaceSpecialCharacter(orderLine.Product.ShortDescription);
 
                     ElavonProduct elavonProduct = new ElavonProduct();
-                    elavonProduct.Ssl_line_Item_commodity_code = CustomStringHelperExtensions.Truncate(orderLine.Product.ErpNumber,16);
+                    elavonProduct.Ssl_line_Item_commodity_code = CustomStringHelperExtensions.Truncate(orderLine.Product.ErpNumber,12);
                     elavonProduct.Ssl_line_item_description = CustomStringHelperExtensions.Truncate(shortDescription,25);
                     elavonProduct.Ssl_line_item_discount_amount = NumberHelper.RoundCurrency(orderLine.TotalNetPrice - orderLine.TotalRegularPrice).ToString();
                     string discountIndicator = "N";


### PR DESCRIPTION
Updated the Ssl_line_Item_commodity_code to truncate to 12 characters as suggested by Elavon to resolve undefined error in elavon response.